### PR TITLE
feat: Add node.js code samples for Chat App link preview

### DIFF
--- a/node/preview-link/README.md
+++ b/node/preview-link/README.md
@@ -1,0 +1,5 @@
+# Preview Link
+
+Provide more information for a link.
+
+For more information on preview link, please read the [guide](https://developers.google.com/chat/how-tos/preview-links).

--- a/node/preview-link/attach-card.js
+++ b/node/preview-link/attach-card.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// [START hangouts_chat_node_preview_link]
+
+/**
+ * Responds to messages that have links whose URLs match URL patterns
+ * configured for link previewing.
+ *
+ * @param {Object} req Request sent from Google Chat.
+ * @param {Object} res Response to send back.
+ */
+exports.onMessage = (req, res) => {
+  if (req.method === 'GET' || !req.body.message) {
+    res.send(
+        'Hello! This function is meant to be used in a Google Chat Space.');
+  }
+
+  // Checks for the presence of event.message.matchedUrl and attaches a card
+  // if present
+  if (req.body.message.matchedUrl) {
+    res.json({
+      'actionResponse': {'type': 'UPDATE_USER_MESSAGE_CARDS'},
+      'cards': [
+        {
+          'header': {
+            'title': 'Example Customer Service Case',
+            'subtitle': 'Case basics',
+          },
+          'sections': [
+            {
+              'widgets': [
+                {'keyValue': {'topLabel': 'Case ID', 'content': 'case123'}},
+                {'keyValue': {'topLabel': 'Assignee', 'content': 'Charlie'}},
+                {'keyValue': {'topLabel': 'Status', 'content': 'Open'}},
+                {'keyValue': {
+                  'topLabel': 'Subject', 'content': 'It won"t turn on...',
+                }},
+              ],
+            },
+            {
+              'widgets': [
+                {
+                  'buttons': [
+                    {
+                      'textButton': {
+                        'text': 'OPEN CASE',
+                        'onClick': {
+                          'openLink': {
+                            'url': 'https://support.example.com/orders/case123',
+                          },
+                        },
+                      },
+                    },
+                    {
+                      'textButton': {
+                        'text': 'RESOLVE CASE',
+                        'onClick': {
+                          'openLink': {
+                            'url': 'https://support.example.com/orders/case123?resolved=y',
+                          },
+                        },
+                      },
+                    },
+                    {
+                      'textButton': {
+                        'text': 'ASSIGN TO ME',
+                        'onClick': {
+                          'action': {
+                            'actionMethodName': 'assign',
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  // If the Chat app doesn’t detect a link preview URL pattern, it says so.
+  res.json({'text': 'No matchedUrl detected.'});
+};
+
+// [END hangouts_chat_node_preview_link]

--- a/node/preview-link/preview-link.js
+++ b/node/preview-link/preview-link.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// [START hangouts_chat_node_preview_link]
+
+/**
+ * Responds to messages that have links whose URLs match URL patterns
+ * configured for link previewing.
+ *
+ * @param {Object} req Request sent from Google Chat.
+ * @param {Object} res Response to send back.
+ */
+exports.onMessage = (req, res) => {
+  if (req.method === 'GET' || !req.body.message) {
+    res.send(
+        'Hello! This function is meant to be used in a Google Chat Space.');
+  }
+
+  // Checks for the presence of event.message.matchedUrl and attaches a card
+  // if present
+  if (req.body.message.matchedUrl) {
+    res.json(createMessage());
+  }
+
+  // Respond to button clicks on attached cards
+  if (req.body.type === 'CARD_CLICKED') {
+    // Checks whether the message event originated from a human or a Chat app
+    // and sets actionResponse.type to "UPDATE_USER_MESSAGE_CARDS if human or
+    // "UPDATE_MESSAGE" if Chat app.
+    const actionResponseType = req.body.action.actionMethodName === 'HUMAN' ?
+      'UPDATE_USER_MESSAGE_CARDS' :
+      'UPDATE_MESSAGE';
+
+    if (req.body.action.actionMethodName === 'assign') {
+      res.json(createMessage(actionResponseType, 'You'));
+    }
+  }
+
+  // If the Chat app doesn’t detect a link preview URL pattern, it says so.
+  res.json({'text': 'No matchedUrl detected.'});
+};
+
+/**
+ * Message to create a card with the correct response type and assignee.
+ *
+ * @param {string} actionResponseType
+ * @param {string} assignee
+ * @return {Object} a card with URL preview
+ */
+function createMessage(
+    actionResponseType = 'UPDATE_USER_MESSAGE_CARDS',
+    assignee = 'Charlie'
+) {
+  return {
+    'actionResponse': {'type': actionResponseType},
+    'cards': [
+      {
+        'header': {
+          'title': 'Example Customer Service Case',
+          'subtitle': 'Case basics',
+        },
+        'sections': [
+          {
+            'widgets': [
+              {'keyValue': {'topLabel': 'Case ID', 'content': 'case123'}},
+              {'keyValue': {'topLabel': 'Assignee', 'content': assignee}},
+              {'keyValue': {'topLabel': 'Status', 'content': 'Open'}},
+              {
+                'keyValue': {
+                  'topLabel': 'Subject', 'content': 'It won"t turn on...',
+                },
+              },
+            ],
+          },
+          {
+            'widgets': [
+              {
+                'buttons': [
+                  {
+                    'textButton': {
+                      'text': 'OPEN CASE',
+                      'onClick': {
+                        'openLink': {
+                          'url': 'https://support.example.com/orders/case123',
+                        },
+                      },
+                    },
+                  },
+                  {
+                    'textButton': {
+                      'text': 'RESOLVE CASE',
+                      'onClick': {
+                        'openLink': {
+                          'url': 'https://support.example.com/orders/case123?resolved=y',
+                        },
+                      },
+                    },
+                  },
+                  {
+                    'textButton': {
+                      'text': 'ASSIGN TO ME',
+                      'onClick': {
+                        'action': {
+                          'actionMethodName': 'assign',
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// [END hangouts_chat_node_preview_link]

--- a/node/preview-link/sender-type.js
+++ b/node/preview-link/sender-type.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// [START hangouts_chat_node_preview_link]
+
+/**
+ * Responds to messages that have links whose URLs match URL patterns
+ * configured for link previewing.
+ *
+ * @param {Object} req Request sent from Google Chat.
+ * @param {Object} res Response to send back.
+ */
+exports.onMessage = (req, res) => {
+  if (req.method === 'GET' || !req.body.message) {
+    res.send(
+        'Hello! This function is meant to be used in a Google Chat Space.');
+  }
+
+  // Respond to button clicks on attached cards
+  if (req.body.type === 'CARD_CLICKED') {
+    // Checks whether the message event originated from a human or a Chat app
+    // and sets actionResponse.type to "UPDATE_USER_MESSAGE_CARDS if human or
+    // "UPDATE_MESSAGE" if Chat app.
+    const actionResponseType = req.body.action.actionMethodName === 'HUMAN' ?
+      'UPDATE_USER_MESSAGE_CARDS' :
+      'UPDATE_MESSAGE';
+
+    res.json({
+      'actionResponse': {
+
+        // Dynamically returns the correct actionResponse type.
+        'type': actionResponseType,
+      },
+
+      // Preview card details
+      'cards': [{}],
+    });
+  }
+};
+
+// [END hangouts_chat_node_preview_link]

--- a/node/preview-link/simple-text-message.js
+++ b/node/preview-link/simple-text-message.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// [START hangouts_chat_node_preview_link]
+
+/**
+ * Responds to messages that have links whose URLs match URL patterns
+ * configured for link previewing.
+ *
+ * @param {Object} req Request sent from Google Chat.
+ * @param {Object} res Response to send back.
+ */
+exports.onMessage = (req, res) => {
+  if (req.method === 'GET' || !req.body.message) {
+    res.send(
+        'Hello! This function is meant to be used in a Google Chat Space.');
+  }
+
+  // Checks for the presence of event.message.matchedUrl and responds with a
+  // text message if present
+  if (req.body.message.matchedUrl) {
+    res.json({
+      'text': 'req.body.message.matchedUrl.url: ' +
+                req.body.message.matchedUrl.url,
+    });
+  }
+
+  // If the Chat app doesn’t detect a link preview URL pattern, it says so.
+  res.json({'text': 'No matchedUrl detected.'});
+};
+
+// [END hangouts_chat_node_preview_link]

--- a/node/preview-link/update-card.js
+++ b/node/preview-link/update-card.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// [START hangouts_chat_node_preview_link]
+
+/**
+ * Responds to messages that have links whose URLs match URL patterns
+ * configured for link previewing.
+ *
+ * @param {Object} req Request sent from Google Chat.
+ * @param {Object} res Response to send back.
+ */
+exports.onMessage = (req, res) => {
+  if (req.method === 'GET' || !req.body.message) {
+    res.send(
+        'Hello! This function is meant to be used in a Google Chat Space.');
+  }
+
+  // Respond to button clicks on attached cards
+  if (req.body.type === 'CARD_CLICKED') {
+    // Checks for the presence of "actionMethodName": "assign" and sets
+    // actionResponse.type to "UPDATE_USER"MESSAGE_CARDS" if present or
+    // "UPDATE_MESSAGE" if absent.
+    const actionResponseType = req.body.action.actionMethodName === 'assign' ?
+      'UPDATE_USER_MESSAGE_CARDS' :
+      'UPDATE_MESSAGE';
+
+    if (req.body.action.actionMethodName === 'assign') {
+      res.json({
+        'actionResponse': {
+
+          // Dynamically returns the correct actionResponse type.
+          'type': actionResponseType,
+        },
+
+        // Preview card details
+        'cards': [{}],
+      });
+    }
+  }
+};
+
+// [END hangouts_chat_node_preview_link]


### PR DESCRIPTION
Move code samples from [here](https://developers.google.com/chat/how-tos/preview-links) to github